### PR TITLE
Change the download links in onnx/models to main

### DIFF
--- a/test/onnx_model_zoo/download.sh
+++ b/test/onnx_model_zoo/download.sh
@@ -1,15 +1,15 @@
 
-wget -c https://github.com/onnx/models/raw/master/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.tar.gz
+wget -c https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.tar.gz
 tar xf tinyyolov2-8.tar.gz
 mv tiny_yolov2/Model.onnx tiny_yolov2/model.onnx
 
-wget -c https://github.com/onnx/models/raw/master/vision/classification/alexnet/model/bvlcalexnet-9.tar.gz
+wget -c https://github.com/onnx/models/raw/main/vision/classification/alexnet/model/bvlcalexnet-9.tar.gz
 tar xf bvlcalexnet-9.tar.gz
 
-wget -c https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.tar.gz
+wget -c https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.1-7.tar.gz
 tar xf squeezenet1.1-7.tar.gz
 mv squeezenet1.1/squeezenet1.1.onnx squeezenet1.1/model.onnx
 
-wget -c https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.tar.gz
+wget -c https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.0-9.tar.gz
 tar xf squeezenet1.0-9.tar.gz
 


### PR DESCRIPTION
See source commit:
https://github.com/onnx/models/commit/87d452a218093f6a60ceb62712ffe1186dce6d64

All this does is fix the links to onnx/models, which changed when that repo renamed to main a few days ago.