### PR TITLE
Update CMAKE_CXX_STANDARD to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(onnx2c
 	VERSION 0.0.1
 	LANGUAGES C CXX
 	)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wfatal-errors")
 


### PR DESCRIPTION
Without this change i get the error `policy_checks.h:79:2: fatal error: "C++ versions less than C++14 are not supported."` when building on my Intel Mac.

My C++ compiler was not outdated. 
```bash
$ g++ -v
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: x86_64-apple-darwin23.3.0
Thread model: posix
```
