### PR TITLE
add missing *int*_t declarations to fix build

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <map>
 #include <string>
+#include <stdint.h>
 
 struct onnx2c_opts
 {


### PR DESCRIPTION
Just fixed a small build issue on Manjaro.