### PR TITLE
Changes to improve compatibility of generated code with (old) msvc

### DIFF
--- a/src/graph_print.cc
+++ b/src/graph_print.cc
@@ -135,7 +135,8 @@ void Graph::print_includes(std::ostream &dst)
 	dst << "#define CLIP(X,L) ( MAX(MIN(X,L), -L) )" << std::endl;
 	dst << std::endl;
 
-	dst << "#ifdef _MSC_VER" << std::endl;
+ 	// 'inline' functions are a C99 addition.
+	dst << "#if __STDC_VERSION__ < 199901L" << std::endl;
 	dst << "#define FUNC_PREFIX" << std::endl;
 	dst << "#else" << std::endl;
 	dst << "#define FUNC_PREFIX static inline" << std::endl;

--- a/src/graph_print.cc
+++ b/src/graph_print.cc
@@ -109,7 +109,7 @@ void Graph::print_functions(std::ostream &dst)
 		dst << " * Operand:           " << n->op_name << std::endl;
 		dst << " * Name in ONNX file: " << n->onnx_name << std::endl;
 		dst << " */" << std::endl;
-		dst << "static inline void ";
+		dst << "FUNC_PREFIX void ";
 		dst << n->c_name() << "( ";
 		n->print_function_parameters_definition(dst);
 		dst << " )";
@@ -128,10 +128,18 @@ void Graph::print_includes(std::ostream &dst)
 	dst << "#include <stdbool.h>" << std::endl;
 	dst << "#include <stdint.h>" << std::endl;
 	dst << "#include <string.h>" << std::endl;
+	dst << std::endl;
 
 	dst << "#define MAX(X,Y) ( X > Y ? X : Y)" << std::endl;
 	dst << "#define MIN(X,Y) ( X < Y ? X : Y)" << std::endl;
 	dst << "#define CLIP(X,L) ( MAX(MIN(X,L), -L) )" << std::endl;
+	dst << std::endl;
+
+	dst << "#ifdef _MSC_VER" << std::endl;
+	dst << "#define FUNC_PREFIX" << std::endl;
+	dst << "#else" << std::endl;
+	dst << "#define FUNC_PREFIX static inline" << std::endl;
+	dst << "#endif" << std::endl;
 
 	if( options.target_avr ) {
 		dst << "#include <avr/pgmspace.h>" << std::endl;

--- a/src/nodes/elementwise_2.h
+++ b/src/nodes/elementwise_2.h
@@ -143,9 +143,20 @@ class Elementwise_2 : public Node {
 		std::string Aidx = "A";
 		std::string Bidx = "B";
 		std::string Cidx = "C";
+
+		std::string line = "unsigned ";
 		for( unsigned r=0; r<C->rank(); r++) {
 			std::string lv = "i" + std::to_string(r);
-			INDT_1 << "for (unsigned " << lv << "=0; " << lv << "<" << C->data_dim[r] << "; " << lv << "++) {" << std::endl;
+			if (r > 0) {
+				line += ", ";
+			}
+			line += lv;
+		}
+		INDT_1 << line << ";" << std::endl;
+
+		for( unsigned r=0; r<C->rank(); r++) {
+			std::string lv = "i" + std::to_string(r);
+			INDT_1 << "for (" << lv << "=0; " << lv << "<" << C->data_dim[r] << "; " << lv << "++) {" << std::endl;
 
 			if (padA[r]==1)
 				Aidx += "[0]";

--- a/src/nodes/matmul.h
+++ b/src/nodes/matmul.h
@@ -50,10 +50,11 @@ class MatMul : public Node {
 		if ( A_is_2d && B_is_2d )
 		{
 			INDT_1 << "/* MatMul */" << std::endl;
-			INDT_1 << "for( uint32_t r=0; r<" << rows << "; r++ )" << std::endl;
-			INDT_2 << "for( uint32_t c=0; c<" << cols << "; c++ ) {" << std::endl;
+			INDT_1 << "uint32_t r, c, i;" << std::endl;
+			INDT_1 << "for( r=0; r<" << rows << "; r++ )" << std::endl;
+			INDT_2 << "for( c=0; c<" << cols << "; c++ ) {" << std::endl;
 			INDT_3 << "Y[r][c] = 0;" << std::endl;
-			INDT_3 << "for( uint32_t i=0; i<" << inner << "; i++ )" << std::endl;
+			INDT_3 << "for( i=0; i<" << inner << "; i++ )" << std::endl;
 			INDT_4 << "Y[r][c] += A[r][i] * B[i][c];" << std::endl;
 			INDT_2 << "}" << std::endl;
 		}

--- a/src/nodes/relu.h
+++ b/src/nodes/relu.h
@@ -14,11 +14,11 @@ class Relu : public Node {
 		std::string type = X->data_type_str();
 
 		dst << "\t/*Relu*/" << std::endl;
-		
 		dst << "\t" << type << " *X_ptr = (" << type << "*)X;" << std::endl;
 		dst << "\t" << type << " *Y_ptr = (" << type << "*)Y;" << std::endl;
+		dst << "\tuint32_t i;" << std::endl;
 
-		dst << "\t" << "for( uint32_t i=0; i<" << X->data_num_elem() << "; i++ )" << std::endl;
+		dst << "\t" << "for( i=0; i<" << X->data_num_elem() << "; i++ )" << std::endl;
 		dst << "\t\tY_ptr[i] = X_ptr[i] > 0 ? X_ptr[i] : 0;" << std::endl;
 		dst << std::endl;
 	} 

--- a/src/nodes/reshape.h
+++ b/src/nodes/reshape.h
@@ -36,8 +36,9 @@ class Reshape : public Node {
 		dst << "\t/*Reshape*/" << std::endl;
 		dst << "\t" << type << " *data_ptr = (" << type << "*)data;" << std::endl;
 		dst << "\t" << type << " *reshaped_ptr = (" << type << "*)reshaped;" << std::endl;
+		dst << "\tuint32_t i;" << std::endl;
 
-		dst << "\t" << "for( uint32_t i=0; i<" << data->data_num_elem() << "; i++ )" << std::endl;
+		dst << "\t" << "for( i=0; i<" << data->data_num_elem() << "; i++ )" << std::endl;
 		dst << "\t\treshaped_ptr[i] = data_ptr[i];" << std::endl;
 		dst << std::endl;
 	}


### PR DESCRIPTION
This pull request contains two commits to improve compatibility with (old) msvc:

- Pull variable definitions out of for(...)
- onnx2c puts the string 'static inline' in front of every function, like here:

---

onnx2c defines counting variables for strings inside the for loops, like here:
    
    for (unsigned i0=0; i0<1; i0++)
    
While this is good practice for modern compilers, older compilers do not accept this. In order to improve compatibility, variables need to be defined at the start of a function. This patch does this for the node types I encountered with my test data.

---

onnx2c puts the string 'static inline' in front of every function, like here:

static inline void node_MatMul( const float A[0][16], const float B[16][50], float Y[0][50] )

Unfortunately, msvc does not accept this. My patch instead introduces a define, FUNC_PREFIX, to control that prefix from a central location (For msvc, I define the string as empty).
