### PR TITLE
Add option for generating without global variables

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -43,6 +43,9 @@ public:
 	/* Optimization step: Fold Cast-nodes to their predecessor. */
 	void fold_casts(void);
 
+	/* Set print options */
+	void set_no_globals(bool ng) { no_globals = ng; }
+
 	void addInitializedTensor(onnx::TensorProto &tensor);
 	Tensor* getIoTensor(onnx::ValueInfoProto &vi);
 
@@ -100,6 +103,9 @@ private:
 	std::vector<Tensor *> tensor_unions;
 	uint32_t add_to_free_union(Tensor *t);
 	void mark_union_unoccupied(uint32_t);
+
+	// Print options
+	bool no_globals = false;
 
 };
 

--- a/src/graph_print.cc
+++ b/src/graph_print.cc
@@ -94,7 +94,10 @@ void Graph::print_global_tensors(std::ostream &dst)
 				print_tensor(t, dst);
 		}
 		dst << "};" <<std::endl;
-		dst << "static union tensor_union_" << u << " tu" << u << ";" << std::endl <<std::endl;
+		if (!no_globals)
+		{
+			dst << "static union tensor_union_" << u << " tu" << u << ";" << std::endl <<std::endl;
+		}
 	}
 	LOG(TRACE) << "(done printing global tensors)"<< std::endl;
 }
@@ -200,6 +203,16 @@ void Graph::print_interface_function(std::ostream &dst, bool definition)
 
 	// else: definition - print the rest
 	dst << "{" << std::endl;
+
+	// Print tensors here if no globals
+	if( no_globals )
+	{
+		for( unsigned u=0; u<tensor_unions.size(); u++ )
+		{
+			INDT_1 << "union tensor_union_" << u << " tu" << u << ";" << std::endl;
+		}
+		dst << std::endl;
+	}
 
 	// since nodes were resolved from graph inputs in the order there were
 	// node inputs resolved, the nodes vector is now sorted in order so that

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,7 +28,7 @@ int main(int argc, const char *argv[])
 		toCgraph.fold_casts();
 	if( options.opt_unionize )
 		toCgraph.unionize_tensors();
-	toCgraph.set_no_globals(options.no_global);
+	toCgraph.set_no_globals(options.no_globals);
 
 	toCgraph.print_source(std::cout);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,6 +28,8 @@ int main(int argc, const char *argv[])
 		toCgraph.fold_casts();
 	if( options.opt_unionize )
 		toCgraph.unionize_tensors();
+	toCgraph.set_no_globals(options.no_global);
+
 	toCgraph.print_source(std::cout);
 }
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -116,6 +116,7 @@ void parse_cmdline_options(int argc, const char *argv[])
 {
 	args::ArgumentParser parser("Generate C code from an ONNX graph file.");
 	args::Flag avr(parser, "avr", "Target AVR-GCC", {'a', "avr"});
+	args::Flag noGlobal(parser, "no-global", "Do not generate global tensors", {'n', "no-global"});
 	args::ValueFlagList<std::string> define(parser, "dim:size", "Define graph input dimension. Can be given multiple times", {'d', "define"});
 	args::ValueFlag<int> loglevel(parser, "level", "Logging verbosity. 0(none)-4(all)", {'l',"log"});
 	args::ValueFlag<std::string> optimizations(parser, "opt[,opt]...", "Specify optimization passes to run. ('help' to list available)", {'p', "optimizations"});
@@ -153,6 +154,7 @@ void parse_cmdline_options(int argc, const char *argv[])
 
 	if (quantize) { options.quantize = true; }
 	if (avr) { options.target_avr = true; }
+	if (noGlobal) { options.no_global = true; }
 	if (define) {
 		for (const auto &d: args::get(define)) {
 			store_define_option(d);

--- a/src/options.cc
+++ b/src/options.cc
@@ -116,7 +116,7 @@ void parse_cmdline_options(int argc, const char *argv[])
 {
 	args::ArgumentParser parser("Generate C code from an ONNX graph file.");
 	args::Flag avr(parser, "avr", "Target AVR-GCC", {'a', "avr"});
-	args::Flag noGlobal(parser, "no-global", "Do not generate global tensors", {'n', "no-global"});
+	args::Flag noGlobals(parser, "no-globals", "Do not generate global tensors", {'n', "no-globals"});
 	args::ValueFlagList<std::string> define(parser, "dim:size", "Define graph input dimension. Can be given multiple times", {'d', "define"});
 	args::ValueFlag<int> loglevel(parser, "level", "Logging verbosity. 0(none)-4(all)", {'l',"log"});
 	args::ValueFlag<std::string> optimizations(parser, "opt[,opt]...", "Specify optimization passes to run. ('help' to list available)", {'p', "optimizations"});
@@ -154,7 +154,7 @@ void parse_cmdline_options(int argc, const char *argv[])
 
 	if (quantize) { options.quantize = true; }
 	if (avr) { options.target_avr = true; }
-	if (noGlobal) { options.no_global = true; }
+	if (noGlobals) { options.no_globals = true; }
 	if (define) {
 		for (const auto &d: args::get(define)) {
 			store_define_option(d);

--- a/src/options.h
+++ b/src/options.h
@@ -12,6 +12,7 @@ struct onnx2c_opts
 {
 	bool quantize=false;
 	bool target_avr=false;
+	bool no_global = false;
 	bool opt_unionize=true;
 	bool opt_fold_casts=true;
 	/*

--- a/src/options.h
+++ b/src/options.h
@@ -12,7 +12,7 @@ struct onnx2c_opts
 {
 	bool quantize=false;
 	bool target_avr=false;
-	bool no_global = false;
+	bool no_globals = false;
 	bool opt_unionize=true;
 	bool opt_fold_casts=true;
 	/*


### PR DESCRIPTION
Adds an option which moves the global variables into the entry function. Useful for multithreaded use of the entry function.