### PR TITLE
Remove VLA from LSTM and unused variables from pad

### DIFF
--- a/src/nodes/lstm.cc
+++ b/src/nodes/lstm.cc
@@ -289,13 +289,13 @@ void LSTM::print(std::ostream &dst) const
 	// TODO: these temporary variables are BIG. Make them global to minimize
 	// stack usage? Probably needs to be an onnx2c flag for user to select
 	INDT_1<<  "/* Forget gate */" << std::endl;
-	INDT_1<<  data_type << " ft[bs][hs];" << std::endl;
+	INDT_1<<  data_type << " ft[" << bs << "][" << hs << "];" << std::endl;
 	INDT_1<<  "/* Input gate */" << std::endl;
-	INDT_1<<  data_type << " it[bs][hs];" << std::endl;
+	INDT_1<<  data_type << " it[" << bs << "][" << hs << "];" << std::endl;
 	INDT_1<<  "/* Cell gate */" << std::endl;
-	INDT_1<<  data_type << " ct[bs][hs];" << std::endl;
+	INDT_1<<  data_type << " ct[" << bs << "][" << hs << "];" << std::endl;
 	INDT_1<<  "/* Output gate */" << std::endl;
-	INDT_1<<  data_type << " ot[bs][hs];" << std::endl;
+	INDT_1<<  data_type << " ot[" << bs << "][" << hs << "];" << std::endl;
 	dst << std::endl;
 
 	/* Initialize cell and hidden state at the start of a run.

--- a/src/nodes/pad.cc
+++ b/src/nodes/pad.cc
@@ -131,7 +131,10 @@ void Pad::print(std::ostream &dst) const
 		INDT(i+1) << "for( uint32_t " << oidx << "=0, " << ilidx << "=0; ";
 		dst <<            oidx << "<" << output->data_dim[i] << "; ";
 		dst <<            oidx <<"++ ) {" << std::endl;
-		INDT(i+2) << "bool " << dopad << "=false;" << std::endl;
+		if ( mode == "constant" )
+		{
+			INDT(i+2) << "bool " << dopad << "=false;" << std::endl;
+		}
 
 		// Handle padding at the 'start' end
 		INDT(i+2) << "if( " << oidx << " < " << paddings_start[i] << "){" << std::endl;


### PR DESCRIPTION
MSVC does not allow VLA so I changed LSTM to use literals rather than variables for array initialization. Also pad generated some unused variables that I changed to only appear when needed.
