### PR TITLE
Add QuantizeLinear node

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -13,3 +13,4 @@ Robin van Emden
 Youngsun Kong
 AUTOMATIC1111
 Thomas Lane
+Can Joshua Lehmann (emmtrix Technologies GmbH)

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -429,6 +429,7 @@ int64_t Graph::onnx_ir_version(void)
 #include "nodes/matmulinteger.h"
 #include "nodes/maxpool.h"
 #include "nodes/pad.h"
+#include "nodes/quantizelinear.h"
 #include "nodes/range.h"
 #include "nodes/reducemean.h"
 #include "nodes/relu.h"
@@ -530,6 +531,7 @@ Node* Graph::createNode(const onnx::NodeProto &onnx_node)
 	if( opName == "Pad" )return new Pad;
 	if( opName == "Pow" )return new Elementwise_2("Pow");
 	if( opName == "PRelu" )return new Elementwise_2("PRelu");
+	if( opName == "QuantizeLinear" )return new QuantizeLinear;
 	if( opName == "Range" )return new Range;
 	if( opName == "ReduceMean" )return new ReduceMean;
 	if( opName == "Reciprocal" )return new Elementwise("Reciprocal");

--- a/src/nodes/quantizelinear.h
+++ b/src/nodes/quantizelinear.h
@@ -1,0 +1,125 @@
+/* This file is part of onnx2c.
+ *
+ * QuantizeLinear node.
+ * 
+ */
+
+#include "node.h"
+
+namespace toC {
+
+class QuantizeLinear : public Node {
+	public:
+	QuantizeLinear() {
+		op_name = "QuantizeLinear";
+		axis = 1;
+	}
+
+	// Attributes
+	int axis;
+
+	virtual void parseAttributes(onnx::NodeProto &node) override;
+	virtual void resolve(void) override;
+	virtual void print(std::ostream &dst) const override;
+};
+
+
+void QuantizeLinear::parseAttributes( onnx::NodeProto &node ) {
+	for( const auto& a : node.attribute() ) {
+		LOG(TRACE) << "Parsing attribute " << a.name() << std::endl;
+		if( a.name() == "axis" )
+			axis = parse_attribute_int(a);
+		else
+			LOG(ERROR) << "Ignoring attribute " << a.name() << " for node QuantizeLinear/" << onnx_name << std::endl;
+	}
+}
+
+void QuantizeLinear::resolve(void) {
+	Tensor *x = get_input_tensor(0);
+	name_input(0, "x");
+	name_input(1, "y_scale");
+
+	if (axis < 0) {
+		axis += x->data_dim.size();
+	}
+
+	onnx::TensorProto_DataType output_data_type = onnx::TensorProto_DataType_UINT8;
+	if (get_number_of_inputs() == 3) {
+		name_input(2, "y_zero_point");
+		Tensor *y_zero_point = get_input_tensor(2);
+		output_data_type = y_zero_point->data_type;
+	}
+	
+	assert(
+		output_data_type == onnx::TensorProto_DataType_INT8 ||
+		output_data_type == onnx::TensorProto_DataType_UINT8 ||
+		output_data_type == onnx::TensorProto_DataType_INT16 ||
+		output_data_type == onnx::TensorProto_DataType_UINT16
+	);
+
+	Tensor *t = new Tensor;
+	t->data_dim = x->data_dim;
+	t->data_type = output_data_type;
+	register_output(t, "y");
+}
+
+void QuantizeLinear::print(std::ostream &dst) const {
+	INDT_1 << "/* QuantizeLinear */" << std::endl;
+
+	Tensor *x = get_input_tensor(0);
+	Tensor *y_scale = get_input_tensor(1);
+	Tensor *y = get_output_tensor(0);
+
+	std::string index;
+	for (unsigned loop_axis = 0; loop_axis < x->rank(); loop_axis++) {
+		std::string name = "i" + std::to_string(loop_axis);
+		INDT_1 << "for (unsigned " << name << " = 0; " << name << " < " << x->data_dim[loop_axis] << "; " << name << "++)" << std::endl;
+
+		index += "[" + name + "]";
+	}
+
+	std::string param_index;
+	assert(y_scale->data_dim.size() == 1);
+	if (y_scale->data_dim[0] == 1) {
+		param_index = "[0]";
+	} else {
+		param_index = "[i" + std::to_string(axis) + "]";
+	}
+
+	INDT_1 << "{" << std::endl;
+	// Transform
+	// We assume that roundf rounds .5 to nearest even
+	INDT_2 << "int t = (int)roundf(x" << index << " / y_scale" << param_index << ")";
+	if (get_number_of_inputs() == 3) {
+		dst << " + (int)y_zero_point" << param_index;
+	}
+	dst << ";" << std::endl;
+	// Saturate
+	int lower, upper;
+	switch (y->data_type) {
+		case onnx::TensorProto_DataType_INT8:
+			lower = -128;
+			upper = 127;
+			break;
+		case onnx::TensorProto_DataType_UINT8:
+			lower = 0;
+			upper = 255;
+			break;
+		case onnx::TensorProto_DataType_INT16:
+			lower = -32768;
+			upper = 32767;
+			break;
+		case onnx::TensorProto_DataType_UINT16:
+			lower = 0;
+			upper = 65535;
+			break;
+		default:
+			ERROR("Unsupported output data type for QuantizeLinear");
+			break;
+	}
+	INDT_2 << "y" << index << " = (" << y->data_type_str() << ")MIN(MAX(t, " << lower << "), " << upper << ");" << std::endl;
+	INDT_1 << "}" << std::endl;
+}
+
+} // namespace
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -672,6 +672,9 @@ ONNX_backend_node_test_singlefile(resize_upsample_sizes_nearest_round_prefer_cei
 local_node_test(resize_downsample_sizes_linear_1D)
 local_node_test(resize_downsample_sizes_linear_1D_align)
 
+ONNX_backend_node_test_singlefile(quantizelinear)
+ONNX_backend_node_test_singlefile(quantizelinear_axis)
+
 # Does not pass: ONNX rounding mode is towards even integer, which does not
 # exist (I think) in C
 #ONNX_backend_node_test(round)


### PR DESCRIPTION
Implements the [QuantizeLinear node](https://onnx.ai/onnx/operators/onnx__QuantizeLinear.html). Does not handle int32 input tensors for now.