### PR TITLE
Fix uninitialized variable warning in SpatialFilter

### DIFF
--- a/src/nodes/spatialfilter.h
+++ b/src/nodes/spatialfilter.h
@@ -135,6 +135,8 @@ class SpatialFilter : public Node {
 				// last output=7
 				int last_out = input_size - filter_size;
 				outdim = last_out / strides[dim] + 1;
+			} else {
+				ERROR("Invalid option for auto_pad attribute");
 			}
 
 			rv.push_back(outdim);


### PR DESCRIPTION
The CI currently fails because `outdim` in `SpatialFilter` may be unintialized. Reporting an error when the `auto_pad` attribute has an invalid value (instead of instead of ignoring) fixes this. My best guess as to why this happens only now is that ubuntu's gcc version was updated.