### PR TITLE
Error if model has no opset version

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -395,8 +395,10 @@ bool Graph::hasUnresolvedNodes(void)
 int64_t Graph::onnx_ir_version(void)
 {
 	int opset_import_size = model.opset_import_size();
-	if( opset_import_size != 1 )
-		LOG(INFO) << "Model has multiple opset versions.";
+	if( opset_import_size == 0 )
+		ERROR("Model has no opset version");
+	if (opset_import_size > 1)
+		LOG(INFO) << "Model has multiple opset versions." << std::endl;
 	auto foo = model.opset_import(0);
 	int64_t version = foo.version();
 	return version;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -397,7 +397,7 @@ int64_t Graph::onnx_ir_version(void)
 	int opset_import_size = model.opset_import_size();
 	if( opset_import_size == 0 )
 		ERROR("Model has no opset version");
-	if (opset_import_size > 1)
+	if( opset_import_size > 1 )
 		LOG(INFO) << "Model has multiple opset versions." << std::endl;
 	auto foo = model.opset_import(0);
 	int64_t version = foo.version();


### PR DESCRIPTION
According to https://github.com/onnx/onnx/blob/main/onnx/onnx.proto#L50, older versions of ONNX did not have any opset imports. This prevents a SEGFAULT in this case.