### PR TITLE
QLinearConv override bugfix

### DIFF
--- a/src/nodes/spatialfilter.h
+++ b/src/nodes/spatialfilter.h
@@ -29,8 +29,8 @@ class SpatialFilter : public Node {
 	std::vector<int64_t> pads;
 	std::vector<int64_t> strides;
 
-	const Tensor* get_X(void) const { return get_input_tensor(0); }
-	const Tensor* get_W(void) const
+	virtual const Tensor* get_X(void) const { return get_input_tensor(0); }
+	virtual const Tensor* get_W(void) const
 	{
 		if (get_number_of_inputs() > 1)
 			return get_input_tensor(1);


### PR DESCRIPTION
This pull request makes the get_X and get_W methods in the SpatialFilter class virtual, allowing derived classes like QLinearConv to override them.

_Motivation_: The change fixes compilation errors caused by derived classes marking these methods as override when the base class methods were not virtual.