### PR TITLE
Add float precision as a command line option (default 20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Onnx2c has a few optimization passes that modify the generated output:
  - Removing `Cast` nodes, by modifying their predecessor node's output tensor.
  - Optimization for AVR processors to put constants into instruction memory.
 
+Floating-point output precision can be configured with `--precision N`.
+If omitted, onnx2c uses a precision of `20`.
+
 `./onnx2c -h` prints out all available command line options.
 
 onnx2c prints a log on stdout. Log level can be given with the `-l N` command line option.

--- a/src/main.cc
+++ b/src/main.cc
@@ -27,7 +27,7 @@ int main(int argc, const char* argv[])
 		ERROR("\"" << options.input_file << "\" is not a valid ONNX model");
 	}
 
-	std::cout.precision(20);
+	std::cout.precision(options.output_precision);
 	toC::Graph toCgraph(onnx_model);
 	if (options.opt_fold_casts)
 		toCgraph.fold_casts();

--- a/src/options.cc
+++ b/src/options.cc
@@ -126,6 +126,7 @@ void parse_cmdline_options(int argc, const char* argv[])
 	args::Flag onlyInit(parser, "only-init", "Only generate initialized tensors (for use with --extern-init)", {'i', "only-init"});
 	args::ValueFlagList<std::string> define(parser, "dim:size", "Define graph input dimension. Can be given multiple times", {'d', "define"});
 	args::ValueFlag<int> loglevel(parser, "level", "Logging verbosity. 0(none)-4(all)", {'l', "log"});
+	args::ValueFlag<int> precision(parser, "digits", "Floating-point output precision (default: 20)", {'P', "precision"});
 	args::ValueFlag<std::string> optimizations(parser, "opt[,opt]...", "Specify optimization passes to run. ('help' to list available)", {'p', "optimizations"});
 	args::ValueFlag<std::string> funcName(parser, "func-name", "The name of the forward pass function", {'f', "func-name"});
 	args::Flag help(parser, "help", "Print this help text.", {'h', "help"});
@@ -157,6 +158,9 @@ void parse_cmdline_options(int argc, const char* argv[])
 	}
 	if (loglevel) {
 		options.logging_level = args::get(loglevel);
+	}
+	if (precision) {
+		options.output_precision = args::get(precision);
 	}
 
 	// initialize logging as soon as possible, so logging is available in parsing the options too

--- a/src/options.h
+++ b/src/options.h
@@ -17,6 +17,7 @@ struct onnx2c_opts {
 	bool only_init = false;
 	bool opt_unionize = true;
 	bool opt_fold_casts = true;
+	int output_precision = 20;
 /*
  * logging levels are
  * cmd line     aixlog     Use


### PR DESCRIPTION
#28: Added command line option for float print precision. defaults to 20.